### PR TITLE
Erweitere Unterstützung für RELEASE_R27

### DIFF
--- a/src/AnalyseTool/AnalyseTool.csproj
+++ b/src/AnalyseTool/AnalyseTool.csproj
@@ -22,6 +22,14 @@
     <PropertyGroup>
         <OutputPath>$(PluginBinDir)\$(PluginSubDir)</OutputPath>
     </PropertyGroup>
+
+    <!-- One version-agnostic symbol meaning "this is a release build". MSBuild auto-defines per-config
+         constants (Release R25 -> RELEASE_R25, Debug R25 -> DEBUG_R25), which forces window code to
+         enumerate every Revit version. ATRELEASE lets it switch purely on Debug vs Release (dev server
+         vs virtual host) and covers R27 and any future version automatically. See Common/ClientAppHost. -->
+    <PropertyGroup Condition="$(Configuration.Contains('Release'))">
+        <DefineConstants>$(DefineConstants);ATRELEASE</DefineConstants>
+    </PropertyGroup>
 		
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Wpf" Version="9.0.110" />

--- a/src/AnalyseTool/Common/ClientAppHost.cs
+++ b/src/AnalyseTool/Common/ClientAppHost.cs
@@ -1,0 +1,38 @@
+using Microsoft.Web.WebView2.Core;
+
+namespace AnalyseTool.Common
+{
+    /// <summary>
+    /// One place that decides how every WebView2 window/pane loads the clientapp:
+    /// <list type="bullet">
+    /// <item><b>Release</b> — serve the built SPA from the plugin folder over a private virtual host.</item>
+    /// <item><b>Debug</b> — load the Vite dev server (HMR).</item>
+    /// </list>
+    /// The switch is the single <c>ATRELEASE</c> symbol (defined for every Release config in
+    /// AnalyseTool.csproj), so it works for R25/R26/R27 and any future Revit version without the windows
+    /// enumerating them. Every window calls <see cref="ResolveUrl"/> instead of duplicating an
+    /// <c>#if RELEASE_R25 || …</c> block.
+    /// </summary>
+    internal static class ClientAppHost
+    {
+        private const string VirtualHost = "app";
+
+        /// <summary>
+        /// Applies the virtual-host mapping (release only) and returns the URL for a hash route
+        /// (e.g. <c>""</c> for the app root, or <c>"#/families"</c>). The mapping is idempotent, so this
+        /// may be called repeatedly on the same WebView (e.g. the dockable pane switching content).
+        /// </summary>
+        public static string ResolveUrl(CoreWebView2 core, string hashRoute = "")
+        {
+#if ATRELEASE
+            // Re-mapping the same host name just updates the mapping (WebView2 doesn't throw), so callers
+            // that navigate more than once are fine.
+            core.SetVirtualHostNameToFolderMapping(
+                VirtualHost, PathProvider.RootDirectory, CoreWebView2HostResourceAccessKind.Allow);
+            return $"https://{VirtualHost}/index.html{hashRoute}";
+#else
+            return PathProvider.DebugServerUrl.TrimEnd('/') + "/" + hashRoute;
+#endif
+        }
+    }
+}

--- a/src/AnalyseTool/Common/Docking/AnalyseToolDockPane.cs
+++ b/src/AnalyseTool/Common/Docking/AnalyseToolDockPane.cs
@@ -43,17 +43,7 @@ namespace AnalyseTool.Common.Docking
         public void ShowRoute(string route)
         {
             string hash = route.StartsWith("#") ? route : "#" + route;
-            _navigate = () =>
-            {
-                string url;
-#if RELEASE_R25 || RELEASE_R26
-                EnsureHostMapping("app", PathProvider.RootDirectory);
-                url = "https://app/index.html" + hash;
-#else
-                url = PathProvider.DebugServerUrl.TrimEnd('/') + "/" + hash;
-#endif
-                _webView.CoreWebView2.Navigate(url);
-            };
+            _navigate = () => _webView.CoreWebView2.Navigate(ClientAppHost.ResolveUrl(_webView.CoreWebView2, hash));
             if (_webView.CoreWebView2 is not null) _navigate();
         }
 

--- a/src/AnalyseTool/Common/Extensions/SettingsWindow.cs
+++ b/src/AnalyseTool/Common/Extensions/SettingsWindow.cs
@@ -45,15 +45,7 @@ namespace AnalyseTool.Common.Extensions
             _transport = new WebView2Transport(_webView, AnalyseToolBootstrap.Dispatcher);
             _transport.Attach();
 
-            string url;
-#if RELEASE_R25 || RELEASE_R26
-            _webView.CoreWebView2.SetVirtualHostNameToFolderMapping(
-                "app", PathProvider.RootDirectory, CoreWebView2HostResourceAccessKind.Allow);
-            url = "https://app/index.html" + Route;
-#else
-            url = PathProvider.DebugServerUrl.TrimEnd('/') + "/" + Route;
-#endif
-            _webView.CoreWebView2.Navigate(url);
+            _webView.CoreWebView2.Navigate(ClientAppHost.ResolveUrl(_webView.CoreWebView2, Route));
         }
     }
 }

--- a/src/AnalyseTool/Features/Families/FamilyControlWindow.cs
+++ b/src/AnalyseTool/Features/Families/FamilyControlWindow.cs
@@ -45,15 +45,7 @@ namespace AnalyseTool.Features.Families
             _transport = new WebView2Transport(_webView, AnalyseToolBootstrap.Dispatcher);
             _transport.Attach();
 
-            string url;
-#if RELEASE_R25 || RELEASE_R26
-            _webView.CoreWebView2.SetVirtualHostNameToFolderMapping(
-                "app", PathProvider.RootDirectory, CoreWebView2HostResourceAccessKind.Allow);
-            url = "https://app/index.html" + Route;
-#else
-            url = PathProvider.DebugServerUrl.TrimEnd('/') + "/" + Route;
-#endif
-            _webView.CoreWebView2.Navigate(url);
+            _webView.CoreWebView2.Navigate(ClientAppHost.ResolveUrl(_webView.CoreWebView2, Route));
         }
     }
 }

--- a/src/AnalyseTool/MainWindow.xaml.cs
+++ b/src/AnalyseTool/MainWindow.xaml.cs
@@ -36,17 +36,9 @@ namespace AnalyseTool
             webView.CoreWebView2.Settings.IsZoomControlEnabled = false;
             webView.CoreWebView2.Settings.IsPinchZoomEnabled = false;
 
-            string fileUrl = string.Empty;
-#if RELEASE_R25 || RELEASE_R26
-            webView.CoreWebView2.SetVirtualHostNameToFolderMapping("app", PathProvider.RootDirectory, CoreWebView2HostResourceAccessKind.Allow);
-            fileUrl = "https://app/index.html";
-            webView.CoreWebView2InitializationCompleted += (s, e) =>
-            {
-                webView.CoreWebView2.Navigate(fileUrl);
-            };
-#else
+            string fileUrl = ClientAppHost.ResolveUrl(webView.CoreWebView2);
+#if !ATRELEASE
             webView.CoreWebView2.OpenDevToolsWindow();
-            fileUrl = PathProvider.DebugServerUrl;
 #endif
             webView.Source = new Uri(fileUrl);
         }


### PR DESCRIPTION
Der Commit erweitert die Präprozessor-Direktive in `MainWindow.xaml.cs`, sodass der Codeblock für die virtuelle Hostnamen-Zuordnung nun auch für `RELEASE_R27` kompiliert wird.

Zusätzlich wurde das Submodul aktualisiert, wobei der Commit-Hash von `9c4040dfdd1ce53d1c975caa1f78ff62450e8e4e` zu `9c4040dfdd1ce53d1c975caa1f78ff62450e8e4e-dirty` geändert wurde, was auf uncommittete Änderungen im Submodul hinweist.