### PR TITLE
ONBOARDING.md: Root-Pfad in Workflow und Packaging

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -11,7 +11,7 @@ on:
   push:
     branches: [main]
     paths:
-      - "src/ONBOARDING.md"
+      - "ONBOARDING.md"
       - "src/LLM.md"
   workflow_dispatch:
 
@@ -32,8 +32,8 @@ jobs:
           git clone "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.wiki.git" wiki
 
           # Map source files to wiki pages. ONBOARDING becomes Home so /wiki lands on the guide.
-          cp src/ONBOARDING.md wiki/Home.md
-          cp src/LLM.md        "wiki/Writing-extensions-with-AI.md"
+          cp ONBOARDING.md wiki/Home.md
+          cp src/LLM.md    "wiki/Writing-extensions-with-AI.md"
 
           cd wiki
           git config user.name  "github-actions[bot]"

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Add a `plugin.json`, build with a year config (`Release R25` / `R26` / `R27`), d
 `%LOCALAPPDATA%\AnalyseTool\extensions\<RevitYear>\`, and hit **Reload**. Your command is now callable
 from JavaScript (`AT.invoke("<id>.CountWalls")`) and from AI clients over MCP — no host rebuild.
 
-📖 **Full authoring guide:** the [GitHub Wiki](https://github.com/Nikola1Davydov/AnalyzeTool/wiki) (mirrored from [`ONBOARDING.md`](src/ONBOARDING.md)) — the manifest, the SDK contract, deploy & live reload, MCP, and more. Writing with AI? Paste [`LLM.md`](src/LLM.md) into Claude/ChatGPT and it writes AnalyseTool extensions for you.
+📖 **Full authoring guide:** the [GitHub Wiki](https://github.com/Nikola1Davydov/AnalyzeTool/wiki) (mirrored from [`ONBOARDING.md`](ONBOARDING.md)) — the manifest, the SDK contract, deploy & live reload, MCP, and more. Writing with AI? Paste [`LLM.md`](src/LLM.md) into Claude/ChatGPT and it writes AnalyseTool extensions for you.
 
 ## Project structure
 

--- a/src/AnalyseTool.Sdk/AnalyseTool.Sdk.csproj
+++ b/src/AnalyseTool.Sdk/AnalyseTool.Sdk.csproj
@@ -56,7 +56,7 @@
   <ItemGroup>
     <None Include="build\AnalyseTool.Sdk.props" Pack="true" PackagePath="build\" />
     <None Include="build\AnalyseTool.Extension.props" Pack="true" PackagePath="build\" />
-    <None Include="..\ONBOARDING.md" Pack="true" PackagePath="\" />
+    <None Include="..\..\ONBOARDING.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Das Sync-Workflow kopiert ONBOARDING.md nun aus dem Root-Verzeichnis ins Wiki und nicht mehr aus `src/`. Der Trigger im Workflow sowie der Link im README.md wurden entsprechend angepasst. Im Projektfile wurde der Pfad für das Packaging auf zwei Ebenen höher geändert. Submodul-Status aktualisiert.