### PR TITLE
Unify license as Apache 2.0 (Sdk stays MIT) + attribution files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2026 Nikolai Davydov
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Nikolai Davydov
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,9 @@
+AnalyseTool
+Copyright 2026 Nikolai Davydov
+
+Licensed under the Apache License, Version 2.0 (see LICENSE).
+The AnalyseTool.Sdk package is licensed separately under the MIT License
+(see src/AnalyseTool.Sdk/LICENSE).
+
+This product bundles third-party software; see THIRD-PARTY-NOTICES.txt
+for the components and their licenses.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![github release version](https://img.shields.io/github/v/release/Nikola1Davydov/AnalyzeTool.svg?include_prereleases)](https://github.com/Nikola1Davydov/AnalyzeTool/releases/latest)
 
-[![license](https://img.shields.io/github/license/Nikola1Davydov/AnalyzeTool.svg)](https://github.com/Nikola1Davydov/AnalyzeTool/blob/master/LICENSE)
+[![license](https://img.shields.io/github/license/Nikola1Davydov/AnalyzeTool.svg)](https://github.com/Nikola1Davydov/AnalyzeTool/blob/main/LICENSE)
 ![Static Badge](https://img.shields.io/badge/revitVersion-2025--2027-blue)
 [![NuGet](https://img.shields.io/nuget/v/AnalyseTool.Sdk.svg?label=SDK)](https://www.nuget.org/packages/AnalyseTool.Sdk)
 [![LINKEDIN](https://img.shields.io/badge/LINKEDIN-_NikolaiDavydov-ff1414)](https://linkedin.com/in/nikolai-davydov-4359bba1)
@@ -215,3 +215,7 @@ composes everything; `Core` and `Tools` are headless (no WPF).
 ## Feedback
 
 Found a bug or have an idea? Use the [issue tracker](https://github.com/Nikola1Davydov/AnalyzeTool/issues) (or the **Report a bug** ribbon button) and attach the latest log from `%LOCALAPPDATA%\AnalyseTool\logs`. PRs welcome.
+
+## License
+
+AnalyseTool is licensed under the [Apache License 2.0](LICENSE), with one exception: the public extension SDK, [`AnalyseTool.Sdk`](src/AnalyseTool.Sdk), is licensed under the [MIT License](src/AnalyseTool.Sdk/LICENSE) so extension authors can consume it without any strings attached. Bundled third-party components are listed in [THIRD-PARTY-NOTICES.txt](THIRD-PARTY-NOTICES.txt).

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -1,0 +1,108 @@
+THIRD-PARTY SOFTWARE NOTICES
+============================
+
+AnalyseTool bundles the following third-party components. They are the
+property of their respective owners and are distributed under the licenses
+named below. Build-time-only tools (NUKE, WixSharp, test frameworks, Vite,
+etc.) are not redistributed with the product and are therefore not listed.
+
+.NET components (shipped in the plugin folder)
+----------------------------------------------
+
+Newtonsoft.Json                                  MIT
+  Copyright (c) James Newton-King
+  https://github.com/JamesNK/Newtonsoft.Json
+
+Serilog / Serilog.Sinks.File                     Apache-2.0
+  Copyright (c) Serilog Contributors
+  https://github.com/serilog/serilog
+
+Microsoft.CodeAnalysis.CSharp (Roslyn)           MIT
+Microsoft.Extensions.AI                          MIT
+Microsoft.Extensions.Hosting                     MIT
+Microsoft.AspNetCore.Components.WebView.Wpf      MIT
+System.Drawing.Common                            MIT
+System.Security.Cryptography.ProtectedData       MIT
+  Copyright (c) .NET Foundation and Contributors
+  https://github.com/dotnet
+
+Microsoft.Web.WebView2                           Microsoft WebView2 SDK license
+  Copyright (c) Microsoft Corporation
+  Redistributable per the package license:
+  https://www.nuget.org/packages/Microsoft.Web.WebView2/ (License)
+
+OllamaSharp                                      MIT
+  Copyright (c) Andreas Wäscher
+  https://github.com/awaescher/OllamaSharp
+
+ModelContextProtocol (C# SDK)                    MIT
+  Copyright (c) Model Context Protocol contributors
+  https://github.com/modelcontextprotocol/csharp-sdk
+
+Web frontend components (bundled into the clientapp)
+----------------------------------------------------
+
+Vue.js                                           MIT
+  Copyright (c) 2018-present, Yuxi (Evan) You and Vue contributors
+  https://github.com/vuejs/core
+
+Vue Router                                       MIT
+  Copyright (c) 2019-present Eduardo San Martin Morote
+  https://github.com/vuejs/router
+
+Pinia                                            MIT
+  Copyright (c) 2019-present Eduardo San Martin Morote
+  https://github.com/vuejs/pinia
+
+PrimeVue / PrimeIcons / @primeuix/themes /       MIT
+tailwindcss-primeui
+  Copyright (c) 2018-present PrimeTek
+  https://github.com/primefaces/primevue
+
+Tailwind CSS                                     MIT
+  Copyright (c) Tailwind Labs, Inc.
+  https://github.com/tailwindlabs/tailwindcss
+
+Chart.js                                         MIT
+  Copyright (c) Chart.js Contributors
+  https://github.com/chartjs/Chart.js
+
+three.js                                         MIT
+  Copyright (c) 2010-2026 three.js authors
+  https://github.com/mrdoob/three.js
+
+marked                                           MIT
+  Copyright (c) 2011-2026, Christopher Jeffrey
+  https://github.com/markedjs/marked
+
+The bundled clientapp also carries the transitive npm dependencies of the
+packages above; their licenses (MIT/ISC) are recorded in
+src/clientapp/package-lock.json.
+
+License texts
+-------------
+
+MIT License (applies to each component marked "MIT" above, with the
+copyright notice given for that component):
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+
+Apache License 2.0 (applies to each component marked "Apache-2.0" above):
+  see the LICENSE file in this distribution or
+  http://www.apache.org/licenses/LICENSE-2.0

--- a/src/AnalyseTool.App/AnalyseTool.App.csproj
+++ b/src/AnalyseTool.App/AnalyseTool.App.csproj
@@ -34,6 +34,9 @@
         <!-- Ships next to the plugin DLL so the Settings window can show it (GetChangelog reads it
              from PathProvider.RootDirectory); the installer bundle picks it up with the bin folder. -->
         <None Include="..\..\CHANGELOG.md" Link="CHANGELOG.md" CopyToOutputDirectory="PreserveNewest" />
+        <!-- License attribution ships with every distributed copy (MSI and bundle) the same way. -->
+        <None Include="..\..\NOTICE" Link="NOTICE" CopyToOutputDirectory="PreserveNewest" />
+        <None Include="..\..\THIRD-PARTY-NOTICES.txt" Link="THIRD-PARTY-NOTICES.txt" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AnalyseTool.Sdk/LICENSE
+++ b/src/AnalyseTool.Sdk/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Nikolai Davydov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/Installer/LICENSE.rtf
+++ b/src/Installer/LICENSE.rtf
@@ -1,242 +1,204 @@
-{\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff50\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi31507\deflang1031\deflangfe1031\themelang1031\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f24\fbidi \froman\fcharset0\fprq2{\*\panose 00000400000000000000}Mangal;}
-{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}{\f45\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Liberation Serif{\*\falt Times New Roman};}
-{\f46\fbidi \fswiss\fcharset0\fprq2{\*\panose 00000000000000000000}Liberation Sans{\*\falt Arial};}{\f47\fbidi \fmodern\fcharset0\fprq1{\*\panose 00000000000000000000}Liberation Mono{\*\falt Courier New};}{\f50\fbidi \fswiss\fcharset0\fprq2 Noto Sans;}
-{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \fswiss\fcharset0\fprq2 Aptos Display;}
-{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2 Aptos;}{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\f1318\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f1319\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f1321\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f1322\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
-{\f1323\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\f1324\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\f1325\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
-{\f1326\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f1328\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}{\f1329\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}{\f1331\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}
-{\f1332\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f1335\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}{\f1336\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}{\f1338\fbidi \fswiss\fcharset238\fprq2 Noto Sans CE;}
-{\f1339\fbidi \fswiss\fcharset204\fprq2 Noto Sans Cyr;}{\f1341\fbidi \fswiss\fcharset161\fprq2 Noto Sans Greek;}{\f1342\fbidi \fswiss\fcharset162\fprq2 Noto Sans Tur;}{\f1345\fbidi \fswiss\fcharset186\fprq2 Noto Sans Baltic;}
-{\f1346\fbidi \fswiss\fcharset163\fprq2 Noto Sans (Vietnamese);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\flomajor\f31509\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
-{\flomajor\f31511\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\flomajor\f31512\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\flomajor\f31513\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
-{\flomajor\f31514\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\flomajor\f31515\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\flomajor\f31516\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}
-{\fdbmajor\f31518\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fdbmajor\f31519\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fdbmajor\f31521\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}
-{\fdbmajor\f31522\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fdbmajor\f31523\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fdbmajor\f31524\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
-{\fdbmajor\f31525\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fdbmajor\f31526\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fhimajor\f31528\fbidi \fswiss\fcharset238\fprq2 Aptos Display CE;}
-{\fhimajor\f31529\fbidi \fswiss\fcharset204\fprq2 Aptos Display Cyr;}{\fhimajor\f31531\fbidi \fswiss\fcharset161\fprq2 Aptos Display Greek;}{\fhimajor\f31532\fbidi \fswiss\fcharset162\fprq2 Aptos Display Tur;}
-{\fhimajor\f31535\fbidi \fswiss\fcharset186\fprq2 Aptos Display Baltic;}{\fhimajor\f31536\fbidi \fswiss\fcharset163\fprq2 Aptos Display (Vietnamese);}{\fbimajor\f31538\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
-{\fbimajor\f31539\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fbimajor\f31541\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fbimajor\f31542\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
-{\fbimajor\f31543\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fbimajor\f31544\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fbimajor\f31545\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
-{\fbimajor\f31546\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\flominor\f31548\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\flominor\f31549\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
-{\flominor\f31551\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\flominor\f31552\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\flominor\f31553\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
-{\flominor\f31554\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\flominor\f31555\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\flominor\f31556\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}
-{\fdbminor\f31558\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fdbminor\f31559\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fdbminor\f31561\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}
-{\fdbminor\f31562\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fdbminor\f31563\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fdbminor\f31564\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
-{\fdbminor\f31565\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fdbminor\f31566\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fhiminor\f31568\fbidi \fswiss\fcharset238\fprq2 Aptos CE;}
-{\fhiminor\f31569\fbidi \fswiss\fcharset204\fprq2 Aptos Cyr;}{\fhiminor\f31571\fbidi \fswiss\fcharset161\fprq2 Aptos Greek;}{\fhiminor\f31572\fbidi \fswiss\fcharset162\fprq2 Aptos Tur;}{\fhiminor\f31575\fbidi \fswiss\fcharset186\fprq2 Aptos Baltic;}
-{\fhiminor\f31576\fbidi \fswiss\fcharset163\fprq2 Aptos (Vietnamese);}{\fbiminor\f31578\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fbiminor\f31579\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
-{\fbiminor\f31581\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fbiminor\f31582\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fbiminor\f31583\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
-{\fbiminor\f31584\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fbiminor\f31585\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fbiminor\f31586\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}}
-{\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;
-\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;\red0\green0\blue0;\red0\green0\blue0;}{\*\defchp \fs24\kerning2\loch\af31506\hich\af31506\dbch\af31505 }{\*\defpap 
-\ql \li0\ri0\sa160\sl278\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }\noqfpromote {\stylesheet{\ql \li0\ri0\nowidctlpar\wrapdefault\hyphpar0\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af50\afs24\alang1081 \ltrch\fcs0 
-\f45\fs24\lang1033\langfe2052\cgrid\langnp1033\langfenp2052 \snext0 \sqformat \spriority0 Normal;}{\*\cs10 \additive \ssemihidden \sunhideused \spriority1 Default Paragraph Font;}{\*
-\ts11\tsrowd\trftsWidthB3\trpaddl108\trpaddr108\trpaddfl3\trpaddft3\trpaddfb3\trpaddfr3\trcbpat1\trcfpat1\tblind0\tblindtype3\tsvertalt\tsbrdrt\tsbrdrl\tsbrdrb\tsbrdrr\tsbrdrdgl\tsbrdrdgr\tsbrdrh\tsbrdrv \ql \li0\ri0\sa160\sl278\slmult1
-\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af31507\afs24\alang1025 \ltrch\fcs0 \fs24\lang1031\langfe1031\kerning2\loch\f31506\hich\af31506\dbch\af31505\cgrid\langnp1031\langfenp1031 
-\snext11 \ssemihidden \sunhideused Normal Table;}{\s15\ql \li0\ri0\sb240\sa120\keepn\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af50\afs28\alang1025 \ltrch\fcs0 \f46\fs28\lang1031\langfe1031\cgrid\langnp1031\langfenp1031 
-\sbasedon0 \snext16 Heading;}{\s16\ql \li0\ri0\sa140\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af31507\afs24\alang1025 \ltrch\fcs0 \fs24\lang1031\langfe1031\loch\f45\hich\af45\dbch\af31505\cgrid\langnp1031\langfenp1031 
-\sbasedon0 \snext16 \slink17 Body Text;}{\*\cs17 \additive \rtlch\fcs1 \af24\afs21\alang1081 \ltrch\fcs0 \f45\fs21\lang1033\langfe2052\kerning0\langnp1033\langfenp2052 \sbasedon10 \slink16 \ssemihidden Textk\'f6rper Zchn;}{
-\s18\ql \li0\ri0\sa140\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af50\afs24\alang1025 \ltrch\fcs0 \fs24\lang1031\langfe1031\loch\f50\hich\af45\dbch\af31505\cgrid\langnp1031\langfenp1031 \sbasedon16 \snext18 List;}{
-\s19\ql \li0\ri0\sb120\sa120\nowidctlpar\noline\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \ai\af50\afs24\alang1025 \ltrch\fcs0 \i\fs24\lang1031\langfe1031\loch\f50\hich\af45\dbch\af31505\cgrid\langnp1031\langfenp1031 \sbasedon0 \snext19 \sqformat 
-caption;}{\s20\ql \li0\ri0\nowidctlpar\noline\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af50\afs24\alang1025 \ltrch\fcs0 \fs24\lang1031\langfe1031\loch\f50\hich\af45\dbch\af31505\cgrid\langnp1031\langfenp1031 \sbasedon0 \snext20 Index;}{
-\s21\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af47\afs20\alang1025 \ltrch\fcs0 \f47\fs20\lang1031\langfe1031\cgrid\langnp1031\langfenp1031 \sbasedon0 \snext21 Preformatted Text;}}{\*\rsidtbl \rsid1602786\rsid6449553
-\rsid10906989}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\author Davydov, Nikolai}{\operator Davydov, Nikolai}{\creatim\yr2025\mo12\dy6\hr19\min52}
-{\revtim\yr2025\mo12\dy6\hr19\min52}{\version2}{\edmins0}{\nofpages1}{\nofwords149}{\nofchars944}{\nofcharsws1091}{\vern1}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
-\paperw12240\paperh15840\margl1134\margr1134\margt1134\margb1134\gutter0\ltrsect 
-\deftab709\widowctrl\ftnbj\aenddoc\hyphhotz425\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0
-\showxmlerrors0\hyphauto1\formshade\horzdoc\dghspace120\dgvspace120\dghorigin1701\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\nobrkwrptbl\rsidroot6449553 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\ftnsep \ltrpar 
-\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\hyphpar0\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af50\afs24\alang1081 \ltrch\fcs0 \f45\fs24\lang1033\langfe2052\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af31507\alang1025 \ltrch\fcs0 
-\lang1031\langfe1031\dbch\af31505\langnp1031\langfenp1031\insrsid10906989 \chftnsep }{\rtlch\fcs1 \af50 \ltrch\fcs0 \insrsid10906989 
-\par }}{\*\ftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\hyphpar0\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af50\afs24\alang1081 \ltrch\fcs0 \f45\fs24\lang1033\langfe2052\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af50 \ltrch\fcs0 
-\insrsid10906989 \chftnsepc 
-\par }}{\*\aftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\hyphpar0\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af50\afs24\alang1081 \ltrch\fcs0 \f45\fs24\lang1033\langfe2052\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af50 \ltrch\fcs0 
-\insrsid10906989 \chftnsep 
-\par }}{\*\aftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\hyphpar0\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af50\afs24\alang1081 \ltrch\fcs0 \f45\fs24\lang1033\langfe2052\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af50 \ltrch\fcs0 
-\insrsid10906989 \chftnsepc 
-\par }}\ltrpar \sectd \ltrsect\sbknone\linex0\sectunlocked1\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2\pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang 
-{\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7
-\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar
-\s21\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af47\afs20\alang1025 \ltrch\fcs0 \f47\fs20\lang1031\langfe1031\cgrid\langnp1031\langfenp1031 {\rtlch\fcs1 \af47 \ltrch\fcs0 
-\lang1033\langfe1031\langnp1033\insrsid10906989\charrsid6449553 MIT License
-\par 
-\par Copyright (c) 2024 Nikolai Davydov
-\par 
-\par Permission is hereby granted, free of charge, to any person obtaining a copy
-\par of this software and associated documentation files (the "Software"), to deal
-\par in the Software without restriction, including without limitation the rights
-\par to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-\par copies of the Software, and to permit persons to whom the Software is
-\par furnished to do so, subject to the following conditions:
-\par 
-\par The above copyright notice and this permission notice shall be included in all
-\par copies or substantial portions of the Software.
-\par 
-\par THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-\par IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-\par FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-\par AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-\par LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-\par OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-\par }{\rtlch\fcs1 \af47 \ltrch\fcs0 \insrsid10906989 SOFTWARE.}{\rtlch\fcs1 \af47 \ltrch\fcs0 \insrsid10906989 
-\par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
-9cb2400825e982c78ec7a27cc0c8992416c9d8b2a755fbf74cd25442a820166c2cd933f79e3be372bd1f07b5c3989ca74aaff2422b24eb1b475da5df374fd9ad
-5689811a183c61a50f98f4babebc2837878049899a52a57be670674cb23d8e90721f90a4d2fa3802cb35762680fd800ecd7551dc18eb899138e3c943d7e503b6
-b01d583deee5f99824e290b4ba3f364eac4a430883b3c092d4eca8f946c916422ecab927f52ea42b89a1cd59c254f919b0e85e6535d135a8de20f20b8c12c3b0
-0c895fcf6720192de6bf3b9e89ecdbd6596cbcdd8eb28e7c365ecc4ec1ff1460f53fe813d3cc7f5b7f020000ffff0300504b030414000600080000002100a5d6
-a7e7c0000000360100000b0000005f72656c732f2e72656c73848fcf6ac3300c87ef85bd83d17d51d2c31825762fa590432fa37d00e1287f68221bdb1bebdb4f
-c7060abb0884a4eff7a93dfeae8bf9e194e720169aaa06c3e2433fcb68e1763dbf7f82c985a4a725085b787086a37bdbb55fbc50d1a33ccd311ba548b6309512
-0f88d94fbc52ae4264d1c910d24a45db3462247fa791715fd71f989e19e0364cd3f51652d73760ae8fa8c9ffb3c330cc9e4fc17faf2ce545046e37944c69e462
-a1a82fe353bd90a865aad41ed0b5b8f9d6fd010000ffff0300504b0304140006000800000021006b799616830000008a0000001c0000007468656d652f746865
-6d652f7468656d654d616e616765722e786d6c0ccc4d0ac3201040e17da17790d93763bb284562b2cbaebbf600439c1a41c7a0d29fdbd7e5e38337cedf14d59b
-4b0d592c9c070d8a65cd2e88b7f07c2ca71ba8da481cc52c6ce1c715e6e97818c9b48d13df49c873517d23d59085adb5dd20d6b52bd521ef2cdd5eb9246a3d8b
-4757e8d3f729e245eb2b260a0238fd010000ffff0300504b03041400060008000000210000e8fdf1fa07000007220000160000007468656d652f7468656d652f
-7468656d65312e786d6cec5a4b8f1bb911be07c87f68f45d5677eb3db0bcd0d3b3f68c3db064077ba4244a4d0fbb2934a99911160b04de532e0b2cb00972c802
-b9e5100459200b64914b7e8c011bc9e647a448b65aa444791e30022398994b37f555f16355b1aa9add0f3fbb4aa87781334e58daf6c30781efe174ca66245db4
-fd97e361a9e97b5ca07486284b71db5f63ee7ff6e897bf78888e448c13ec817cca8f50db8f85581e95cb7c0ac3883f604b9cc26f73962548c06db628cf327409
-7a135a8e82a05e4e10497d2f4509a87d3e9f9329f61f6dd40e28e84e059703539a8da452bc8f9d9d8712c1d7bc4733ef02d1b60f33ccd8e5185f09dfa3880bf8
-a1ed07eacf2f3f7a584647b9101507640db9a1facbe57281d979a4e6cc169362d2601035ab61a15f01a8d8c70d9af2bfd0a700683a85956a2ea6ceb0560f9a51
-8e3540fad2a1bbd5082b36ded05fd9e31cb6eadda86ae95720adbfba870f86ad41bf66e11548e36b7bf84e10755b150baf401a5fdfc357079d4634b0f00a1453
-929eefa3eb8d66b39ea30bc89cd16327bc55af078d7e0edfa2201a8ae89253cc592a0ec55a825eb36c080009a44890d413eb259ea329c46f672918f7fa842f29
-5afbde12a58cc370108521845e35888a7f6571748491212d790113be3724f9787c9a91a568fb4f40ab6f40defdf4d3db373fbe7df3f7b75f7ffdf6cd5fbd13b2
-88855665c91da37461cafdfca76ffff3fdafbd7fffed8f3f7ff75b379e9bf8f77ff9cdfb7ffcf343ea61ab6d4df1ee773fbcfff18777bfffe65f7ffecea1bd93
-a189091f930473ef19bef45eb00416a84c61f3c793ec7612e3181153a2932e384a919cc5a17f20620bfd6c8d2872e0bad8b6e3ab0c528d0bf878f5da223c8ab3
-95200e8d4fe3c4029e3246bb2c735ae1a99ccb30f378952edc93672b13f702a10bd7dc3d945a5e1eac969063894b652fc616cd338a52811638c5c293bfb1738c
-1dabfb8210cbaea7649a31cee6c2fb82785d449c26199389154d5ba16392805fd62e82e06fcb36a7afbc2ea3ae55f7f1858d84bd81a883fc1853cb8c8fd14aa0
-c4a5728c126a1afc0489d84572b4cea6266ec005787a8129f30633ccb94be67906eb359cfe14417673bafd94ae131b990972eed279821833917d76de8b51b274
-6147248d4dece7fc1c421479674cb8e0a7ccde21f21efc80d283ee7e45b0e5eeebb3c14bc87226a56d80c85f5699c3978f31b3e277b4a673845da9a69325568a
-ed64c4191dddd5c20aed138c29ba44338cbd979f3b1874d9d2b2f996f49318b2ca317605d61364c7aabc4f31c79e6a6ef6f3e409e156c88ef0821de073bade49
-3c6b9426283ba4f91978ddb4f96092c16674acf3399d9e9bc06704ba3f8817a7519e73d06104f741ad6731b20a98bce7ee785d6796ff6eb2c7605fbeb668dc60
-5f820cbeb50c247653e683b619236a4db00d983122de892bdd8288e5fead882cae4a6ce5949bdb9b76eb06e88eaca62721e9351dd0ffaef381fee2dd1fbe7784
-e0c7e976dc8aad5475cb3ee7502a39dee96e0ee1767b9a1ecb66e4d36f69fa68959e61a822fbf9eabea3b9ef68fcfffb8ee6d07ebeef630e751bf77d8c0ffdc5
-7d1f931fad7c9c3e66dbba4057238f17f4318f3af4490e9ef9cc09a523b1a6f884ab631f0e4f33b3210c4a3975d2898b33c0650c97b2ccc104166e912125e365
-4cfc8a887814a3259c0d85be54b2e0b9ea05f7968cc391911a76ea9678ba4a4ed94c1f75aab3a54057568ec4763ca8c1a1931e87632aa1d1f5463e28f9a9f354
-e0abd82ed431eb868094bd0d0963329b44c541a2b119bc86843c35fb382c5a0e164da97ee3aa3d5300b5c22bf0b8edc1437adbaf552521381de75368cd67d24f
-dad51bef2a677e4c4f1f32a6150170aca85702c7f185a75b92ebc1e5c9d5e950bb81a72d12ca293aac6c12ca32aac1e3313c04e7d129476f42e3b6be6e6d5d6a
-d193a650f3417c6f69349a1f6271575f83dc6e6ea0a9992968ea5dc21e8f60d3f9de142ddbfe1cce8ce1325942f070f9c885e8025eb94c45a677fc5d52cb32e3
-a28f78ac2daeb28ef64f4204ce3c4a92b62fd75ff881a62a8968722dd8ba9f2ab9486eb84f8d1c78ddf6329ecff154987e3746a4a5f52da4789d2c9cbf2af1bb
-83a5245b81bb47f1ecd29bd055f6024188d51aa1f4ee8c707875106a57cf08bc0b2b32d936fe762a539efdcd97512a86f438a2cb18e525c5cce61aae0a4a4147
-dd153630eef23583410d93e49570b29015d634aa554e8bdaa5391c2cbbd70b49cb1959735b34adb422cba63b8d59336ceac08e2def56e50d561b134352334bbc
-ceddbb39b7b549763b8d425126c0e085fdee56fb0d6adbc92c6a92f17e1e96493b1fb58bc76681d750bb499530d27e7da376c76e4591704e0783772afd20b71b
-b53034df3496cad2ea75b9f95e9b4d5e43f2e8439bbba2fa4d374de14e46255f9e65cab713365be79794eb44a37d2e9b5289a4e90b3cf7c8ecaaed47aece51bf
-6d0df36e40a1a5982c5e85a0b3dbb30573bc14d51bb610d6015e0495de94b67021a16686debb1056278a2edae26a4359f6ea805726e47ad560dadc5270b56f45
-78f59f21e86d47aab3d3b917685f893cbfc095b7ca48dbff32a875aabda8d62b05cddaa054ad548352b3d6a9943ab55a251cd4c2a0df8dbe027a224ec29afede
-61082f81e83affea418def7df9906cde733d98b2a4ccd4970d65e57df5e5431839be7cf0c6f203071f1c09b4a241588d3a51afd4eb87f55235ead74bcd46a553
-ea45f57ed481a25d1f76bef2bd0b050ebbfdfe70588b4af51ee0aa41a756ea742bbd52bd39e846c37050ed0700cecbcf153cc580cd36b6804bc5ebd17f010000
-ffff0300504b0304140006000800000021000dd1909fb60000001b010000270000007468656d652f7468656d652f5f72656c732f7468656d654d616e61676572
-2e786d6c2e72656c73848f4d0ac2301484f78277086f6fd3ba109126dd88d0add40384e4350d363f2451eced0dae2c082e8761be9969bb979dc9136332de3168
-aa1a083ae995719ac16db8ec8e4052164e89d93b64b060828e6f37ed1567914b284d262452282e3198720e274a939cd08a54f980ae38a38f56e422a3a641c8bb
-d048f7757da0f19b017cc524bd62107bd5001996509affb3fd381a89672f1f165dfe514173d9850528a2c6cce0239baa4c04ca5bbabac4df000000ffff030050
-4b01022d0014000600080000002100e9de0fbfff0000001c0200001300000000000000000000000000000000005b436f6e74656e745f54797065735d2e786d6c
-504b01022d0014000600080000002100a5d6a7e7c0000000360100000b00000000000000000000000000300100005f72656c732f2e72656c73504b01022d0014
-0006000800000021006b799616830000008a0000001c00000000000000000000000000190200007468656d652f7468656d652f7468656d654d616e616765722e
-786d6c504b01022d001400060008000000210000e8fdf1fa070000072200001600000000000000000000000000d60200007468656d652f7468656d652f746865
-6d65312e786d6c504b01022d00140006000800000021000dd1909fb60000001b0100002700000000000000000000000000040b00007468656d652f7468656d652f5f72656c732f7468656d654d616e616765722e786d6c2e72656c73504b050600000000050005005d010000ff0b00000000}
-{\*\colorschememapping 3c3f786d6c2076657273696f6e3d22312e302220656e636f64696e673d225554462d3822207374616e64616c6f6e653d22796573223f3e0d0a3c613a636c724d
-617020786d6c6e733a613d22687474703a2f2f736368656d61732e6f70656e786d6c666f726d6174732e6f72672f64726177696e676d6c2f323030362f6d6169
-6e22206267313d226c743122207478313d22646b3122206267323d226c743222207478323d22646b322220616363656e74313d22616363656e74312220616363
-656e74323d22616363656e74322220616363656e74333d22616363656e74332220616363656e74343d22616363656e74342220616363656e74353d22616363656e74352220616363656e74363d22616363656e74362220686c696e6b3d22686c696e6b2220666f6c486c696e6b3d22666f6c486c696e6b222f3e}
-{\*\latentstyles\lsdstimax376\lsdlockeddef0\lsdsemihiddendef0\lsdunhideuseddef0\lsdqformatdef0\lsdprioritydef99{\lsdlockedexcept \lsdqformat1 \lsdpriority0 \lsdlocked0 Normal;\lsdqformat1 \lsdpriority9 \lsdlocked0 heading 1;
-\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 2;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 3;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 4;
-\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 5;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 6;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 7;
-\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 8;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 9;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 1;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 5;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 6;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 7;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 8;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 9;
-\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 1;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 2;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 3;
-\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 4;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 5;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 6;
-\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 7;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 8;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 9;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Normal Indent;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 footnote text;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 annotation text;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 header;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 footer;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index heading;\lsdqformat1 \lsdlocked0 caption;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 table of figures;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 envelope address;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 envelope return;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 footnote reference;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 annotation reference;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 line number;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 page number;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 endnote reference;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 endnote text;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 table of authorities;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 macro;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 toa heading;\lsdsemihidden1 \lsdlocked0 List;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Bullet;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Number;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List 5;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Bullet 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Bullet 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Bullet 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Bullet 5;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Number 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Number 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Number 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Number 5;
-\lsdqformat1 \lsdpriority10 \lsdlocked0 Title;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Closing;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Signature;\lsdsemihidden1 \lsdunhideused1 \lsdpriority1 \lsdlocked0 Default Paragraph Font;
-\lsdsemihidden1 \lsdlocked0 Body Text;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text Indent;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Continue;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Continue 2;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Continue 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Continue 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Continue 5;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Message Header;
-\lsdqformat1 \lsdpriority11 \lsdlocked0 Subtitle;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Salutation;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Date;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text First Indent;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text First Indent 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Note Heading;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text 3;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text Indent 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text Indent 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Block Text;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Hyperlink;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 FollowedHyperlink;\lsdqformat1 \lsdpriority22 \lsdlocked0 Strong;\lsdqformat1 \lsdpriority20 \lsdlocked0 Emphasis;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Document Map;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Plain Text;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 E-mail Signature;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Top of Form;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Bottom of Form;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Normal (Web);\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Acronym;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Address;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Cite;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Code;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Definition;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Keyboard;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Preformatted;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Sample;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Typewriter;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Variable;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Normal Table;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 annotation subject;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 No List;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Outline List 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Outline List 2;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Outline List 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Simple 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Simple 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Simple 3;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Classic 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Classic 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Classic 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Classic 4;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Colorful 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Colorful 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Colorful 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Columns 1;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Columns 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Columns 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Columns 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Columns 5;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 4;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 5;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 6;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 7;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Grid 8;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 4;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 5;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 6;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 7;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table List 8;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table 3D effects 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table 3D effects 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table 3D effects 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Contemporary;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Elegant;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Professional;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Subtle 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Subtle 2;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Web 1;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Web 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Web 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Balloon Text;
-\lsdpriority39 \lsdlocked0 Table Grid;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Table Theme;\lsdsemihidden1 \lsdlocked0 Placeholder Text;\lsdqformat1 \lsdpriority1 \lsdlocked0 No Spacing;\lsdpriority60 \lsdlocked0 Light Shading;
-\lsdpriority61 \lsdlocked0 Light List;\lsdpriority62 \lsdlocked0 Light Grid;\lsdpriority63 \lsdlocked0 Medium Shading 1;\lsdpriority64 \lsdlocked0 Medium Shading 2;\lsdpriority65 \lsdlocked0 Medium List 1;\lsdpriority66 \lsdlocked0 Medium List 2;
-\lsdpriority67 \lsdlocked0 Medium Grid 1;\lsdpriority68 \lsdlocked0 Medium Grid 2;\lsdpriority69 \lsdlocked0 Medium Grid 3;\lsdpriority70 \lsdlocked0 Dark List;\lsdpriority71 \lsdlocked0 Colorful Shading;\lsdpriority72 \lsdlocked0 Colorful List;
-\lsdpriority73 \lsdlocked0 Colorful Grid;\lsdpriority60 \lsdlocked0 Light Shading Accent 1;\lsdpriority61 \lsdlocked0 Light List Accent 1;\lsdpriority62 \lsdlocked0 Light Grid Accent 1;\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 1;
-\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 1;\lsdpriority65 \lsdlocked0 Medium List 1 Accent 1;\lsdsemihidden1 \lsdlocked0 Revision;\lsdqformat1 \lsdpriority34 \lsdlocked0 List Paragraph;\lsdqformat1 \lsdpriority29 \lsdlocked0 Quote;
-\lsdqformat1 \lsdpriority30 \lsdlocked0 Intense Quote;\lsdpriority66 \lsdlocked0 Medium List 2 Accent 1;\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 1;\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 1;\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 1;
-\lsdpriority70 \lsdlocked0 Dark List Accent 1;\lsdpriority71 \lsdlocked0 Colorful Shading Accent 1;\lsdpriority72 \lsdlocked0 Colorful List Accent 1;\lsdpriority73 \lsdlocked0 Colorful Grid Accent 1;\lsdpriority60 \lsdlocked0 Light Shading Accent 2;
-\lsdpriority61 \lsdlocked0 Light List Accent 2;\lsdpriority62 \lsdlocked0 Light Grid Accent 2;\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 2;\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 2;\lsdpriority65 \lsdlocked0 Medium List 1 Accent 2;
-\lsdpriority66 \lsdlocked0 Medium List 2 Accent 2;\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 2;\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 2;\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 2;\lsdpriority70 \lsdlocked0 Dark List Accent 2;
-\lsdpriority71 \lsdlocked0 Colorful Shading Accent 2;\lsdpriority72 \lsdlocked0 Colorful List Accent 2;\lsdpriority73 \lsdlocked0 Colorful Grid Accent 2;\lsdpriority60 \lsdlocked0 Light Shading Accent 3;\lsdpriority61 \lsdlocked0 Light List Accent 3;
-\lsdpriority62 \lsdlocked0 Light Grid Accent 3;\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 3;\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 3;\lsdpriority65 \lsdlocked0 Medium List 1 Accent 3;\lsdpriority66 \lsdlocked0 Medium List 2 Accent 3;
-\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 3;\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 3;\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 3;\lsdpriority70 \lsdlocked0 Dark List Accent 3;\lsdpriority71 \lsdlocked0 Colorful Shading Accent 3;
-\lsdpriority72 \lsdlocked0 Colorful List Accent 3;\lsdpriority73 \lsdlocked0 Colorful Grid Accent 3;\lsdpriority60 \lsdlocked0 Light Shading Accent 4;\lsdpriority61 \lsdlocked0 Light List Accent 4;\lsdpriority62 \lsdlocked0 Light Grid Accent 4;
-\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 4;\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 4;\lsdpriority65 \lsdlocked0 Medium List 1 Accent 4;\lsdpriority66 \lsdlocked0 Medium List 2 Accent 4;
-\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 4;\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 4;\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 4;\lsdpriority70 \lsdlocked0 Dark List Accent 4;\lsdpriority71 \lsdlocked0 Colorful Shading Accent 4;
-\lsdpriority72 \lsdlocked0 Colorful List Accent 4;\lsdpriority73 \lsdlocked0 Colorful Grid Accent 4;\lsdpriority60 \lsdlocked0 Light Shading Accent 5;\lsdpriority61 \lsdlocked0 Light List Accent 5;\lsdpriority62 \lsdlocked0 Light Grid Accent 5;
-\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 5;\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 5;\lsdpriority65 \lsdlocked0 Medium List 1 Accent 5;\lsdpriority66 \lsdlocked0 Medium List 2 Accent 5;
-\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 5;\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 5;\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 5;\lsdpriority70 \lsdlocked0 Dark List Accent 5;\lsdpriority71 \lsdlocked0 Colorful Shading Accent 5;
-\lsdpriority72 \lsdlocked0 Colorful List Accent 5;\lsdpriority73 \lsdlocked0 Colorful Grid Accent 5;\lsdpriority60 \lsdlocked0 Light Shading Accent 6;\lsdpriority61 \lsdlocked0 Light List Accent 6;\lsdpriority62 \lsdlocked0 Light Grid Accent 6;
-\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 6;\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 6;\lsdpriority65 \lsdlocked0 Medium List 1 Accent 6;\lsdpriority66 \lsdlocked0 Medium List 2 Accent 6;
-\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 6;\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 6;\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 6;\lsdpriority70 \lsdlocked0 Dark List Accent 6;\lsdpriority71 \lsdlocked0 Colorful Shading Accent 6;
-\lsdpriority72 \lsdlocked0 Colorful List Accent 6;\lsdpriority73 \lsdlocked0 Colorful Grid Accent 6;\lsdqformat1 \lsdpriority19 \lsdlocked0 Subtle Emphasis;\lsdqformat1 \lsdpriority21 \lsdlocked0 Intense Emphasis;
-\lsdqformat1 \lsdpriority31 \lsdlocked0 Subtle Reference;\lsdqformat1 \lsdpriority32 \lsdlocked0 Intense Reference;\lsdqformat1 \lsdpriority33 \lsdlocked0 Book Title;\lsdsemihidden1 \lsdunhideused1 \lsdpriority37 \lsdlocked0 Bibliography;
-\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority39 \lsdlocked0 TOC Heading;\lsdpriority41 \lsdlocked0 Plain Table 1;\lsdpriority42 \lsdlocked0 Plain Table 2;\lsdpriority43 \lsdlocked0 Plain Table 3;\lsdpriority44 \lsdlocked0 Plain Table 4;
-\lsdpriority45 \lsdlocked0 Plain Table 5;\lsdpriority40 \lsdlocked0 Grid Table Light;\lsdpriority46 \lsdlocked0 Grid Table 1 Light;\lsdpriority47 \lsdlocked0 Grid Table 2;\lsdpriority48 \lsdlocked0 Grid Table 3;\lsdpriority49 \lsdlocked0 Grid Table 4;
-\lsdpriority50 \lsdlocked0 Grid Table 5 Dark;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful;\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful;\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 1;\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 1;
-\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 1;\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 1;\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 1;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 1;
-\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 1;\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 2;\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 2;\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 2;
-\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 2;\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 2;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 2;\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 2;
-\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 3;\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 3;\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 3;\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 3;
-\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 3;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 3;\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 3;\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 4;
-\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 4;\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 4;\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 4;\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 4;
-\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 4;\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 4;\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 5;\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 5;
-\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 5;\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 5;\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 5;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 5;
-\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 5;\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 6;\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 6;\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 6;
-\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 6;\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 6;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 6;\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 6;
-\lsdpriority46 \lsdlocked0 List Table 1 Light;\lsdpriority47 \lsdlocked0 List Table 2;\lsdpriority48 \lsdlocked0 List Table 3;\lsdpriority49 \lsdlocked0 List Table 4;\lsdpriority50 \lsdlocked0 List Table 5 Dark;
-\lsdpriority51 \lsdlocked0 List Table 6 Colorful;\lsdpriority52 \lsdlocked0 List Table 7 Colorful;\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 1;\lsdpriority47 \lsdlocked0 List Table 2 Accent 1;\lsdpriority48 \lsdlocked0 List Table 3 Accent 1;
-\lsdpriority49 \lsdlocked0 List Table 4 Accent 1;\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 1;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 1;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 1;
-\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 2;\lsdpriority47 \lsdlocked0 List Table 2 Accent 2;\lsdpriority48 \lsdlocked0 List Table 3 Accent 2;\lsdpriority49 \lsdlocked0 List Table 4 Accent 2;
-\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 2;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 2;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 2;\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 3;
-\lsdpriority47 \lsdlocked0 List Table 2 Accent 3;\lsdpriority48 \lsdlocked0 List Table 3 Accent 3;\lsdpriority49 \lsdlocked0 List Table 4 Accent 3;\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 3;
-\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 3;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 3;\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 4;\lsdpriority47 \lsdlocked0 List Table 2 Accent 4;
-\lsdpriority48 \lsdlocked0 List Table 3 Accent 4;\lsdpriority49 \lsdlocked0 List Table 4 Accent 4;\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 4;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 4;
-\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 4;\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 5;\lsdpriority47 \lsdlocked0 List Table 2 Accent 5;\lsdpriority48 \lsdlocked0 List Table 3 Accent 5;
-\lsdpriority49 \lsdlocked0 List Table 4 Accent 5;\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 5;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 5;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 5;
-\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 6;\lsdpriority47 \lsdlocked0 List Table 2 Accent 6;\lsdpriority48 \lsdlocked0 List Table 3 Accent 6;\lsdpriority49 \lsdlocked0 List Table 4 Accent 6;
-\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 6;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 6;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 6;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Mention;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Hyperlink;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Hashtag;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Unresolved Mention;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Link;}}{\*\datastore 01050000
-02000000180000004d73786d6c322e534158584d4c5265616465722e362e3000000000000000000000060000
-d0cf11e0a1b11ae1000000000000000000000000000000003e000300feff090006000000000000000000000001000000010000000000000000100000feffffff00000000feffffff0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000003040
-3183e166dc01feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
-00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
-000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
-0000000000000000000000000000000000000000000000000105000000000000}}
+{\rtf1\ansi\ansicpg1252\deff0{\fonttbl{\f0\fmodern\fcharset0 Courier New;}}
+\f0\fs18
+                                 Apache License\par
+                           Version 2.0, January 2004\par
+                        http://www.apache.org/licenses/\par
+\par
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\par
+\par
+   1. Definitions.\par
+\par
+      "License" shall mean the terms and conditions for use, reproduction,\par
+      and distribution as defined by Sections 1 through 9 of this document.\par
+\par
+      "Licensor" shall mean the copyright owner or entity authorized by\par
+      the copyright owner that is granting the License.\par
+\par
+      "Legal Entity" shall mean the union of the acting entity and all\par
+      other entities that control, are controlled by, or are under common\par
+      control with that entity. For the purposes of this definition,\par
+      "control" means (i) the power, direct or indirect, to cause the\par
+      direction or management of such entity, whether by contract or\par
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the\par
+      outstanding shares, or (iii) beneficial ownership of such entity.\par
+\par
+      "You" (or "Your") shall mean an individual or Legal Entity\par
+      exercising permissions granted by this License.\par
+\par
+      "Source" form shall mean the preferred form for making modifications,\par
+      including but not limited to software source code, documentation\par
+      source, and configuration files.\par
+\par
+      "Object" form shall mean any form resulting from mechanical\par
+      transformation or translation of a Source form, including but\par
+      not limited to compiled object code, generated documentation,\par
+      and conversions to other media types.\par
+\par
+      "Work" shall mean the work of authorship, whether in Source or\par
+      Object form, made available under the License, as indicated by a\par
+      copyright notice that is included in or attached to the work\par
+      (an example is provided in the Appendix below).\par
+\par
+      "Derivative Works" shall mean any work, whether in Source or Object\par
+      form, that is based on (or derived from) the Work and for which the\par
+      editorial revisions, annotations, elaborations, or other modifications\par
+      represent, as a whole, an original work of authorship. For the purposes\par
+      of this License, Derivative Works shall not include works that remain\par
+      separable from, or merely link (or bind by name) to the interfaces of,\par
+      the Work and Derivative Works thereof.\par
+\par
+      "Contribution" shall mean any work of authorship, including\par
+      the original version of the Work and any modifications or additions\par
+      to that Work or Derivative Works thereof, that is intentionally\par
+      submitted to Licensor for inclusion in the Work by the copyright owner\par
+      or by an individual or Legal Entity authorized to submit on behalf of\par
+      the copyright owner. For the purposes of this definition, "submitted"\par
+      means any form of electronic, verbal, or written communication sent\par
+      to the Licensor or its representatives, including but not limited to\par
+      communication on electronic mailing lists, source code control systems,\par
+      and issue tracking systems that are managed by, or on behalf of, the\par
+      Licensor for the purpose of discussing and improving the Work, but\par
+      excluding communication that is conspicuously marked or otherwise\par
+      designated in writing by the copyright owner as "Not a Contribution."\par
+\par
+      "Contributor" shall mean Licensor and any individual or Legal Entity\par
+      on behalf of whom a Contribution has been received by Licensor and\par
+      subsequently incorporated within the Work.\par
+\par
+   2. Grant of Copyright License. Subject to the terms and conditions of\par
+      this License, each Contributor hereby grants to You a perpetual,\par
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\par
+      copyright license to reproduce, prepare Derivative Works of,\par
+      publicly display, publicly perform, sublicense, and distribute the\par
+      Work and such Derivative Works in Source or Object form.\par
+\par
+   3. Grant of Patent License. Subject to the terms and conditions of\par
+      this License, each Contributor hereby grants to You a perpetual,\par
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\par
+      (except as stated in this section) patent license to make, have made,\par
+      use, offer to sell, sell, import, and otherwise transfer the Work,\par
+      where such license applies only to those patent claims licensable\par
+      by such Contributor that are necessarily infringed by their\par
+      Contribution(s) alone or by combination of their Contribution(s)\par
+      with the Work to which such Contribution(s) was submitted. If You\par
+      institute patent litigation against any entity (including a\par
+      cross-claim or counterclaim in a lawsuit) alleging that the Work\par
+      or a Contribution incorporated within the Work constitutes direct\par
+      or contributory patent infringement, then any patent licenses\par
+      granted to You under this License for that Work shall terminate\par
+      as of the date such litigation is filed.\par
+\par
+   4. Redistribution. You may reproduce and distribute copies of the\par
+      Work or Derivative Works thereof in any medium, with or without\par
+      modifications, and in Source or Object form, provided that You\par
+      meet the following conditions:\par
+\par
+      (a) You must give any other recipients of the Work or\par
+          Derivative Works a copy of this License; and\par
+\par
+      (b) You must cause any modified files to carry prominent notices\par
+          stating that You changed the files; and\par
+\par
+      (c) You must retain, in the Source form of any Derivative Works\par
+          that You distribute, all copyright, patent, trademark, and\par
+          attribution notices from the Source form of the Work,\par
+          excluding those notices that do not pertain to any part of\par
+          the Derivative Works; and\par
+\par
+      (d) If the Work includes a "NOTICE" text file as part of its\par
+          distribution, then any Derivative Works that You distribute must\par
+          include a readable copy of the attribution notices contained\par
+          within such NOTICE file, excluding those notices that do not\par
+          pertain to any part of the Derivative Works, in at least one\par
+          of the following places: within a NOTICE text file distributed\par
+          as part of the Derivative Works; within the Source form or\par
+          documentation, if provided along with the Derivative Works; or,\par
+          within a display generated by the Derivative Works, if and\par
+          wherever such third-party notices normally appear. The contents\par
+          of the NOTICE file are for informational purposes only and\par
+          do not modify the License. You may add Your own attribution\par
+          notices within Derivative Works that You distribute, alongside\par
+          or as an addendum to the NOTICE text from the Work, provided\par
+          that such additional attribution notices cannot be construed\par
+          as modifying the License.\par
+\par
+      You may add Your own copyright statement to Your modifications and\par
+      may provide additional or different license terms and conditions\par
+      for use, reproduction, or distribution of Your modifications, or\par
+      for any such Derivative Works as a whole, provided Your use,\par
+      reproduction, and distribution of the Work otherwise complies with\par
+      the conditions stated in this License.\par
+\par
+   5. Submission of Contributions. Unless You explicitly state otherwise,\par
+      any Contribution intentionally submitted for inclusion in the Work\par
+      by You to the Licensor shall be under the terms and conditions of\par
+      this License, without any additional terms or conditions.\par
+      Notwithstanding the above, nothing herein shall supersede or modify\par
+      the terms of any separate license agreement you may have executed\par
+      with Licensor regarding such Contributions.\par
+\par
+   6. Trademarks. This License does not grant permission to use the trade\par
+      names, trademarks, service marks, or product names of the Licensor,\par
+      except as required for reasonable and customary use in describing the\par
+      origin of the Work and reproducing the content of the NOTICE file.\par
+\par
+   7. Disclaimer of Warranty. Unless required by applicable law or\par
+      agreed to in writing, Licensor provides the Work (and each\par
+      Contributor provides its Contributions) on an "AS IS" BASIS,\par
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\par
+      implied, including, without limitation, any warranties or conditions\par
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\par
+      PARTICULAR PURPOSE. You are solely responsible for determining the\par
+      appropriateness of using or redistributing the Work and assume any\par
+      risks associated with Your exercise of permissions under this License.\par
+\par
+   8. Limitation of Liability. In no event and under no legal theory,\par
+      whether in tort (including negligence), contract, or otherwise,\par
+      unless required by applicable law (such as deliberate and grossly\par
+      negligent acts) or agreed to in writing, shall any Contributor be\par
+      liable to You for damages, including any direct, indirect, special,\par
+      incidental, or consequential damages of any character arising as a\par
+      result of this License or out of the use or inability to use the\par
+      Work (including but not limited to damages for loss of goodwill,\par
+      work stoppage, computer failure or malfunction, or any and all\par
+      other commercial damages or losses), even if such Contributor\par
+      has been advised of the possibility of such damages.\par
+\par
+   9. Accepting Warranty or Additional Liability. While redistributing\par
+      the Work or Derivative Works thereof, You may choose to offer,\par
+      and charge a fee for, acceptance of support, warranty, indemnity,\par
+      or other liability obligations and/or rights consistent with this\par
+      License. However, in accepting such obligations, You may act only\par
+      on Your own behalf and on Your sole responsibility, not on behalf\par
+      of any other Contributor, and only if You agree to indemnify,\par
+      defend, and hold each Contributor harmless for any liability\par
+      incurred by, or claims asserted against, such Contributor by reason\par
+      of your accepting any such warranty or additional liability.\par
+\par
+   END OF TERMS AND CONDITIONS\par
+\par
+   APPENDIX: How to apply the Apache License to your work.\par
+\par
+      To apply the Apache License to your work, attach the following\par
+      boilerplate notice, with the fields enclosed by brackets "[]"\par
+      replaced with your own identifying information. (Don't include\par
+      the brackets!)  The text should be enclosed in the appropriate\par
+      comment syntax for the file format. We also recommend that a\par
+      file or class name and description of purpose be included on the\par
+      same "printed page" as the copyright notice for easier\par
+      identification within third-party archives.\par
+\par
+   Copyright 2026 Nikolai Davydov\par
+\par
+   Licensed under the Apache License, Version 2.0 (the "License");\par
+   you may not use this file except in compliance with the License.\par
+   You may obtain a copy of the License at\par
+\par
+       http://www.apache.org/licenses/LICENSE-2.0\par
+\par
+   Unless required by applicable law or agreed to in writing, software\par
+   distributed under the License is distributed on an "AS IS" BASIS,\par
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\par
+   See the License for the specific language governing permissions and\par
+   limitations under the License.\par
+}


### PR DESCRIPTION
Resolves the license inconsistency on `dev` (root `LICENSE` and the installer said MIT while `src/AnalyseTool.App/license.txt` was already Apache 2.0) and adds the attribution files that were missing. Related to #66 ("licence adapt in installer") and the per-project licensing item of #67.

## Changes

**License unification (Apache 2.0 everywhere except the Sdk)**
- `LICENSE`: replaced MIT with the full Apache 2.0 text (matches `src/AnalyseTool.App/license.txt` and the `LICENSE` already on `main`)
- `src/Installer/LICENSE.rtf`: regenerated from the Apache 2.0 text, so the MSI wizard shows the correct license
- `AnalyseTool.Sdk` deliberately **keeps MIT** (`PackageLicenseExpression` untouched): the public SDK contract stays permissive for extension authors, per #67

**Attribution**
- `src/AnalyseTool.Sdk/LICENSE`: MIT text for the SDK, so the license is visible in the repo and not only in NuGet metadata
- `NOTICE`: Apache 2.0 §4(d) attribution that redistributors must preserve
- `THIRD-PARTY-NOTICES.txt`: bundled .NET and frontend components with their licenses; ships next to the plugin DLL together with `NOTICE` via `AnalyseTool.App.csproj` (same mechanism as `CHANGELOG.md`), so the MSI and bundle carry it too
- `README.md`: new License section (Apache 2.0 + MIT Sdk); fixed the license badge that pointed at the non-existent `master` branch

## Notes
- `THIRD-PARTY-NOTICES.txt` is a manually curated list based on `Directory.Packages.props` and `clientapp/package.json` — new runtime dependencies need to be added to it
- Build-time-only tools (NUKE, WixSharp, test frameworks) are intentionally not listed, as they are not redistributed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwKy22D6CJrheLSc12jqXS